### PR TITLE
exclude tables option

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,6 +67,11 @@
         "By default, VACUUM will be performed automatically after migration (recommended)",
         "This behavior can be disabled for tables, included into the list (Array) below."
     ],
-    "no_vacuum" : []
+    "no_vacuum" : [],
+
+    "exclude_tables_description": [
+        "List (Array) of tables not to be migrated."
+    ],
+    "exclude_tables": []
 }
 

--- a/migration/fmtp/FromMySQL2PostgreSQL.js
+++ b/migration/fmtp/FromMySQL2PostgreSQL.js
@@ -553,6 +553,9 @@ FromMySQL2PostgreSQL.prototype.loadStructureToMigrate = function(self) {
                                 for (let i = 0; i < rows.length; i++) {
                                     let relationName = rows[i]['Tables_in_' + self._mySqlDbName];
 
+                                    // skip excluded tables 
+                                    if(self._config.exclude_tables && self._config.exclude_tables.find(x => x===relationName)) continue;
+
                                     if (rows[i].Table_type === 'BASE TABLE') {
                                         self._tablesToMigrate.push(relationName);
                                         processTablePromises.push(self.processTable(self, relationName));


### PR DESCRIPTION
Ability to define tables that should be excluded from migration. 

A whitelist of tables to import might also be interesting. 