### PR TITLE
Support for COPY FROM STDIN to allow loading into a remote PostgreSQL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Anatoly Khaytovich<anatolyuss@gmail.com>",
   "dependencies": {
     "mysql": "*",
-    "pg": "*"
+    "pg": "*",
+    "pg-copy-streams": "*"
   }
 }


### PR DESCRIPTION
This is a bit of a hack as it stands and could do with some attention before merging - I managed to get it to work for my case but unfortunately may not have time to round out the implementation.

It uses https://github.com/brianc/node-pg-copy-streams to stream the data via STDIN instead of from a local file on the PostgreSQL server.

There is a hardcoded var 'localCopy' in DataLoader.js:153 that toggles between file and stream - this should probably become a config var.

The streamed COPY doesn't seem to return the row count, so I don't send the MessageToMaster with the row counts - not sure what that is actually for anyway.

Anyway, I'm presenting this PR on the off chance that someone may find it useful, as it worked for me, or has the time to fix it up and merge it in.
