### PR TITLE
ATHN-1542 Customize migration to suit Athena

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,6 +67,7 @@
         "If not supplied, then 1 MB will be used as a default."
     ],
     "data_chunk_size" : 1,
+
     "no_vacuum_description" : [
         "PostgreSQL VACUUM reclaims storage occupied by dead tuples. VACUUM is a very time-consuming procedure.",
         "By default, VACUUM will be performed automatically after migration (recommended)",
@@ -84,6 +85,12 @@
         "In order to skip schema migration, and just migrate data into a preset schema",
         " - set this parameter true"
     ],
-    "migrate_only_data" : false
+    "migrate_only_data" : false,
+
+    "convert_tinyint_to_boolean_description": [
+        "In MySQL, boolean is just an alias of tinyint, and tinyint can contain a lot more values than 0 or 1.",
+        "If you are sure that in your database tinyint is used only as boolean, then set this option to true"
+    ],
+    "convert_tinyint_to_boolean": false
 }
 

--- a/config.json
+++ b/config.json
@@ -91,6 +91,6 @@
         "In MySQL, boolean is just an alias of tinyint, and tinyint can contain a lot more values than 0 or 1.",
         "If you are sure that in your database tinyint is used only as boolean, then set this option to true"
     ],
-    "convert_tinyint_to_boolean": false
+    "convert_tinyint_to_boolean": true
 }
 

--- a/migration/fmtp/Conversion.js
+++ b/migration/fmtp/Conversion.js
@@ -80,4 +80,6 @@ module.exports = function Conversion(config) {
     this._loaderMaxOldSpaceSize = this._config.loader_max_old_space_size;
     this._loaderMaxOldSpaceSize = isIntNumeric(this._loaderMaxOldSpaceSize) ? this._loaderMaxOldSpaceSize : 'DEFAULT';
     this._migrateOnlyData       = this._config.migrate_only_data;
+
+    this._convertTinyintToBoolean = this._config.convert_tinyint_to_boolean;
 };

--- a/migration/fmtp/DataTypesMapReader.js
+++ b/migration/fmtp/DataTypesMapReader.js
@@ -29,7 +29,7 @@ const fs = require('fs');
  * @param   {Conversion} self
  * @returns {Promise}
  */
-module.exports = function(self) {
+module.exports = function (self) {
     return new Promise((resolve, reject) => {
         fs.readFile(self._dataTypesMapAddr, (error, data) => {
             if (error) {
@@ -39,6 +39,11 @@ module.exports = function(self) {
                 try {
                     self._dataTypesMap = JSON.parse(data.toString());
                     console.log('\t--[readDataTypesMap] Data Types Map is loaded...');
+                    if (self._convertTinyintToBoolean) {
+                        self._dataTypesMap.tinyint.increased_size = '';
+                        self._dataTypesMap.tinyint.type = 'boolean';
+                        console.log('\t--[readDataTypesMap] Will transform tinyint fields to boolean...');
+                    }
                     resolve();
                 } catch (err) {
                     console.log('\t--[readDataTypesMap] Cannot parse JSON from' + self._dataTypesMapAddr);

--- a/migration/fmtp/DefaultProcessor.js
+++ b/migration/fmtp/DefaultProcessor.js
@@ -77,6 +77,9 @@ module.exports = function(self, tableName) {
 
                                     if (sqlReservedValues[self._dicTables[tableName].arrTableColumns[i].Default]) {
                                         sql += sqlReservedValues[self._dicTables[tableName].arrTableColumns[i].Default] + ';';
+                                    } else if (self._convertTinyintToBoolean && self._dicTables[tableName].arrTableColumns[i].Type.indexOf('tinyint') !== -1) {
+                                        let value = parseInt(self._dicTables[tableName].arrTableColumns[i].Default);
+                                        sql += value === 0 ? 'FALSE' : 'TRUE';
                                     } else {
                                         sql += isFloatNumeric(self._dicTables[tableName].arrTableColumns[i].Default)
                                                ? self._dicTables[tableName].arrTableColumns[i].Default + ';'

--- a/migration/fmtp/IndexAndKeyProcessor.js
+++ b/migration/fmtp/IndexAndKeyProcessor.js
@@ -49,7 +49,6 @@ module.exports = function(self, tableName) {
                             resolveProcessIndexAndKey();
                         } else {
                             let objPgIndices               = Object.create(null);
-                            let cnt                        = 0;
                             let indexType                  = '';
                             let processIndexAndKeyPromises = [];
 
@@ -81,7 +80,7 @@ module.exports = function(self, tableName) {
 
                                                 } else {
                                                     // "schema_idxname_{integer}_idx" - is NOT a mistake.
-                                                    let columnName = objPgIndices[attr].column_name[0].slice(1, -1) + cnt++;
+                                                    let columnName = objPgIndices[attr].column_name[0].slice(1, -1);
                                                     indexType      = 'index';
                                                     sql            = 'CREATE ' + (objPgIndices[attr].is_unique ? 'UNIQUE ' : '') + 'INDEX "'
                                                                    + self._schema + '_' + tableName + '_' + columnName + '_idx" ON "'

--- a/migration/fmtp/IndexAndKeyProcessor.js
+++ b/migration/fmtp/IndexAndKeyProcessor.js
@@ -83,7 +83,7 @@ module.exports = function(self, tableName) {
                                                     let columnName = objPgIndices[attr].column_name[0].slice(1, -1);
                                                     indexType      = 'index';
                                                     sql            = 'CREATE ' + (objPgIndices[attr].is_unique ? 'UNIQUE ' : '') + 'INDEX "'
-                                                                   + self._schema + '_' + tableName + '_' + columnName + '_idx" ON "'
+                                                                   + tableName + '_' + columnName + '_idx" ON "'
                                                                    + self._schema + '"."' + tableName + '" '
                                                                    + objPgIndices[attr].Index_type + ' (' + objPgIndices[attr].column_name.join(',') + ');';
                                                 }


### PR DESCRIPTION
There are a number of discrepancies between the default migration and what we'd like to see with regards to the schema, outlined in [ATHN-1542](https://nanometrics.atlassian.net/browse/ATHN-1542). This addresses the easy ones, leaving the rest to be handled by a database migration in Athena. 

What remains:
```
DROP INDEX schema_migrations_version_idx;
DROP INDEX users_persistence_token_idx;
ALTER TABLE channels
	ALTER COLUMN channel_code SET DEFAULT ''::character varying;
ALTER TABLE groups
	ALTER COLUMN name SET DEFAULT ''::character varying;
ALTER TABLE networks
	ALTER COLUMN network_code SET DEFAULT ''::character varying;
ALTER TABLE recipients
	ALTER COLUMN name SET DEFAULT ''::character varying,
	ALTER COLUMN email SET DEFAULT ''::character varying;
ALTER TABLE roles
	ALTER COLUMN name SET DEFAULT ''::character varying;
ALTER TABLE routes
	ALTER COLUMN name SET DEFAULT ''::character varying;
ALTER TABLE stations
	ALTER COLUMN station_code SET DEFAULT ''::character varying;
ALTER TABLE users
	ALTER COLUMN perishable_token SET DEFAULT ''::character varying;
CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
CREATE INDEX index_users_on_persistence_token ON users USING btree (persistence_token);
```


