### PR TITLE
Fixes extra-config-path-resolution.

### DIFF
--- a/src/FsOps.ts
+++ b/src/FsOps.ts
@@ -107,14 +107,14 @@ export function readConfig(confPath: string, logsPath: string, configFileName: s
 /**
  * Reads the extra configuration file, if necessary.
  */
-export function readExtraConfig(config: any, confPath: string): Promise<any> {
+export function readExtraConfig(config: any, confPath: string, extraConfigFileName: string = 'extra_config.json'): Promise<any> {
     return new Promise<any>(resolve => {
         if (config.enable_extra_config !== true) {
             config.extraConfig = null;
             return resolve(config);
         }
 
-        const pathToExtraConfig = path.join(confPath, 'config', 'extra_config.json');
+        const pathToExtraConfig = path.join(confPath, extraConfigFileName);
 
         fs.readFile(pathToExtraConfig, (error: ErrnoException | null, data: Buffer) => {
             if (error) {


### PR DESCRIPTION
Fixes #74.

I added a parameter `extraConfigFileName` to be consistent with the method signature of `export function readConfig(confPath: string, logsPath: string, configFileName: string = 'config.json'): Promise<any>`.
Further I changed the `path.join` to also be consistent with `const pathToConfig = path.join(confPath, configFileName);`.