### PR TITLE
Fix duplicate index names caused by 63 char limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 <h3>NMIG - the database migration tool.</h3>
 
+<h4>Fork</h4>
+Simon Hewitt  
+simon.d.hewitt@gmail.com
+<ol>
+<li>Index names can exceed the 63 character Postgres limit, 
+for these names truncate to 57 chars and add 6 chars of a UUID tag to the end
+</li>
+<li>
+MySQL stores UUID values as varchar(36) (or(32)?). 
+NMIG seems to be truncating these on conversion. Add a config.json element
+that saves them as Postgres UUID datatypes.
+</li>
+</ol>
 <h3>WHAT IS IT ALL ABOUT?</h3>
 <p>NMIG is an app, intended to make a process of migration
 from MySQL to PostgreSQL as easy and smooth as possible.</p>

--- a/config/config.json
+++ b/config/config.json
@@ -12,12 +12,12 @@
     ],
     "source" : {
         "host"             : "localhost",
-        "port"             : 3306,
-        "database"         : "test_db",
+        "port"             : 3316,
+        "database"         : "db",
         "charset"          : "utf8mb4",
         "supportBigNumbers": true,
-        "user"             : "root",
-        "password"         : "0123456789"
+        "user"             : "simon",
+        "password"         : "whmcc"
     },
 
     "target_description" : [
@@ -28,11 +28,11 @@
     ],
     "target" : {
         "host"     : "localhost",
-        "port"     : 5432,
-        "database" : "test_db",
+        "port"     : 5430,
+        "database" : "db",
         "charset"  : "UTF8",
-        "user"     : "postgres",
-        "password" : "0123456789"
+        "user"     : "simon",
+        "password" : "whmcc"
     },
 
     "max_each_db_connection_pool_size_description" : [
@@ -99,6 +99,12 @@
         "By default, nmig will migrate all tables."
     ],
     "include_tables": [],
+
+    "uuid_columns_description": [
+        "List the table.column of any MySQL columns that contain UUID values",
+        "And should be stored in Postgres UUID data types"
+    ],
+    "uuid_columns": ["uuid_test.uuid"],
 
     "migrate_only_data_description" : [
         "In order to skip schema migration, and just migrate data into a preset tables",

--- a/count_rows.sh
+++ b/count_rows.sh
@@ -1,0 +1,9 @@
+echo Count rows in MySQL and Postgres
+echo
+mysql -h localhost -u simon -pwhmcc -P3316 db << EOF
+select count(*) as MySQL from uuid_test;
+EOF
+echo
+PGPASSWORD=whmcc psql -h 127.0.0.1 --port=5430 -U simon --dbname=db << EOF
+select count(*) as Postgres from uuid_test;
+EOF

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
                 "json2csv": "^5.0.6",
                 "mysql": "^2.18.1",
                 "pg": "^8.7.3",
-                "pg-copy-streams": "^6.0.2"
+                "pg-copy-streams": "^6.0.2",
+                "uuid": "^8.3.2"
             },
             "devDependencies": {
                 "@types/tape": "^4.13.2",
+                "@types/uuid": "^8.3.4",
                 "tape": "^5.5.0",
                 "typescript": "4.5.5"
             },
@@ -57,6 +59,12 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "node_modules/array.prototype.every": {
             "version": "1.1.3",
@@ -750,9 +758,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "node_modules/mysql": {
@@ -1186,6 +1194,14 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/which-boxed-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
@@ -1284,6 +1300,12 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/uuid": {
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+            "dev": true
         },
         "array.prototype.every": {
             "version": "1.1.3",
@@ -1794,9 +1816,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "mysql": {
@@ -2131,6 +2153,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         },
         "which-boxed-primitive": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -18,17 +18,20 @@
         "json2csv": "^5.0.6",
         "mysql": "^2.18.1",
         "pg": "^8.7.3",
-        "pg-copy-streams": "^6.0.2"
+        "pg-copy-streams": "^6.0.2",
+        "uuid": "^8.3.2"
     },
     "devDependencies": {
         "@types/tape": "^4.13.2",
+        "@types/uuid": "^8.3.4",
         "tape": "^5.5.0",
         "typescript": "4.5.5"
     },
     "scripts": {
         "build": "tsc --incremental -p tsconfig.json",
         "start": "node dist/src/Main.js",
-        "test": "node dist/test/Main.test.js"
+        "test": "node dist/test/Main.test.js",
+        "count": "./count_rows.sh"
     },
     "keywords": [
         "database migration",

--- a/src/Conversion.ts
+++ b/src/Conversion.ts
@@ -113,6 +113,11 @@ export default class Conversion {
     public readonly _includeTables: string[];
 
     /**
+     * List of tables.columns to be saved as Postgres uuid data types
+     */
+    public readonly _uuidColumns: string[];
+
+    /**
      * The timestamp, at which the migration began.
      */
     public readonly _timeBegin: Date;
@@ -223,6 +228,7 @@ export default class Conversion {
         this._notCreatedViewsPath = path.join(this._logsDirPath, 'not_created_views');
         this._excludeTables = this._config.exclude_tables === undefined ? [] : this._config.exclude_tables;
         this._includeTables = this._config.include_tables === undefined ? [] : this._config.include_tables;
+        this._uuidColumns = this._config.uuid_columns === undefined ? [] : this._config.uuid_columns;
         this._timeBegin = new Date();
         this._encoding = this._config.encoding === undefined ? 'utf8' : this._config.encoding;
         this._0777 = '0777';


### PR DESCRIPTION
Update IndexAndKeyProcessor.ts
    Postgres limits all object names to 63 chars **nmig** creates index names with:

    `${ conversion._schema }_${ tableName }_${ columnName }_idx`

    Eg `public_accounts_referrerlogin_user_domain_id0_idx` where:

    * _public_ is the schema name
    * _accounts_referrerlogin_ is the table name
    * _user_domain_id_ is the column being indexed
    * Dunno where the _0_ comes from
    * __idx_ is fixed

    This frequently exceeded 63 characters, and when this happens, Postgres simply truncates the name to 63 chars. Now in several cases, the 63 character truncated string was not unique, i.e. the `{ conversion._schema }_${ tableName }_` element was already 63 chars (or some compound indices sharing the same first column). This error showed as:

    `error: duplicate key value violates unique constraint "pg_class_relname_nsp_index"`
    i.e. a unique constraint on the index name itself.

    This change detects index names > 63 chars, and alters then by truncating the created index name to 53 chars then appendix a 6-char UUID fragment, giving a unique index name (very unlikely to have a clash on even 6 UUID chars foir this limited use range)