### PR TITLE
Add the possibility to convert all column names to lower case.

### DIFF
--- a/src/ExtraConfigProcessor.ts
+++ b/src/ExtraConfigProcessor.ts
@@ -39,21 +39,28 @@ export const getTableName = (conversion: Conversion, currentTableName: string, s
  * Retrieves current column's name.
  */
 export const getColumnName = (conversion: Conversion, originalTableName: string, currentColumnName: string, shouldGetOriginal: boolean): string => {
-    if (conversion._extraConfig !== null && 'tables' in conversion._extraConfig) {
-        for (let i: number = 0; i < conversion._extraConfig.tables.length; ++i) {
-            if (conversion._extraConfig.tables[i].name.original === originalTableName && 'columns' in conversion._extraConfig.tables[i]) {
-                for (let columnsCount: number = 0; columnsCount < conversion._extraConfig.tables[i].columns.length; ++columnsCount) {
-                    if (conversion._extraConfig.tables[i].columns[columnsCount].original === currentColumnName) {
-                        return shouldGetOriginal
-                            ? conversion._extraConfig.tables[i].columns[columnsCount].original
-                            : conversion._extraConfig.tables[i].columns[columnsCount].new;
+    let retVal: string = currentColumnName;
+
+    if (conversion._extraConfig !== null) {
+        if ('tables' in conversion._extraConfig) {
+            for (let i: number = 0; i < conversion._extraConfig.tables.length; ++i) {
+                if (conversion._extraConfig.tables[i].name.original === originalTableName && 'columns' in conversion._extraConfig.tables[i]) {
+                    for (let columnsCount: number = 0; columnsCount < conversion._extraConfig.tables[i].columns.length; ++columnsCount) {
+                        if (conversion._extraConfig.tables[i].columns[columnsCount].original === currentColumnName) {
+                            retVal = shouldGetOriginal
+                                ? conversion._extraConfig.tables[i].columns[columnsCount].original
+                                : conversion._extraConfig.tables[i].columns[columnsCount].new;
+                        }
                     }
                 }
             }
         }
+        if (conversion._extraConfig.lowerCaseAllColumnNames && !shouldGetOriginal) {
+            retVal = retVal.toLowerCase();
+        }
     }
 
-    return currentColumnName;
+    return retVal;
 };
 
 /**


### PR DESCRIPTION
In MySQL column names are case insensitive.
PostgreSQL folds column names in queries to lower case, but considers column names with upper case letters in them as different, requiring the use of double quotes around the column name and using the proper case when refering to that column. That causes queries that worked on MySQL to fail on PostgreSQL. Converting all column names to lower case during migration avoids this issue.