### PR TITLE
Add Dockerfile to repository

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,30 @@
+**Note: Docker support is a work in progress. The following instructions may not work exactly as expected across operating systems and environments.**
+
+<h3>RUNNING WITH DOCKER</h3>
+
+<p>Nmig can run inside a Docker container while connecting to MySQL and PostgreSQL on the host machine.</p>
+
+<p><b>1.</b> Follow instructions in the "USAGE" section in README.md to:
+   <ol type=a>
+   <li>Download the Nmig repository.</li>
+   <li>Create a PostgreSQL database.</li>
+   <li>Edit the necessary files in the <code>config</code> directory.</li>
+   </ol>
+</p>
+<p><b>2.</b> Build a Docker image from the <code>nmig</code> directory. <pre>$ docker build --tag my-migration . </pre>
+
+<p><b>3.</b> Mount the edited <code>config</code> directory and run Nmig in a new Docker container.<br/>
+<pre>$ docker run --rm \
+    --mount type=bind,source=/path/to/nmig_config,target=/usr/src/app/config \
+    my-migration \
+    npm start
+</pre>
+</p>
+<p>
+<b>Notes: </b>
+<ul>
+   <li>These steps require Docker. Consult <a href="https://www.docker.com">the official Docker site</a> for download and installation instructions.</li>
+   <li>In configuration files, the <code>target.host</code> and <code>source.host</code> properties will be <code>"host.docker.internal"</code> instead of <code>"localhost"</code>.</li>
+   <li>The examples above use "my-migration" as the image tag, but it can be any name you choose.</p>
+</p>
+</ul>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=20
+
+FROM node:${NODE_VERSION}-alpine
+
+WORKDIR /usr/src/app
+
+# Copy source files into the image.
+COPY . .
+
+# Install dependencies, and build
+RUN npm install && npm run build
+
+# Expose default PostgreSQL and MySQL ports
+EXPOSE 5432
+EXPOSE 3306
+


### PR DESCRIPTION
This adds a Dockerfile to the repository with corresponding instructions in `DOCKER.md`

Running Nmig in a Docker container will allow users to perform migrations without installing npm dependencies locally. It could also allow for easier automation or use in build pipelines.

Notes:
- I have tested this Dockerfile and these commands multiple times on MacOS.
- I have not verified that the commands and the instructions are 100% valid for Docker on Windows and Linux. (working on it)
- I have not yet successfully run `npm test` inside a container but have also not yet thoroughly investigated.
- I'm guessing this will work with [podman](https://podman.io/) or related runtimes but I also haven't tested and am not sure how important that would be.

All feedback welcome! Just wanted to get the process started and see if this is even something @AnatolyUss is interested in adding to Nmig.