### PR TITLE
Fix double quotes in WHERE statement when include/exclude tables spec…

### DIFF
--- a/src/StructureLoader.ts
+++ b/src/StructureLoader.ts
@@ -75,7 +75,7 @@ export default async (conversion: Conversion): Promise<Conversion> => {
 
     if (conversion._includeTables.length !== 0) {
         const tablesToInclude: string = conversion._includeTables
-            .map((table: string): string => `"${table}"`)
+            .map((table: string): string => `'${table}'`)
             .join(',');
 
         sql += ` AND Tables_in_${conversion._mySqlDbName} IN(${tablesToInclude})`;
@@ -83,7 +83,7 @@ export default async (conversion: Conversion): Promise<Conversion> => {
 
     if (conversion._excludeTables.length !== 0) {
         const tablesToExclude: string = conversion._excludeTables
-            .map((table: string): string => `"${table}"`)
+            .map((table: string): string => `'${table}'`)
             .join(',');
 
         sql += ` AND Tables_in_${conversion._mySqlDbName} NOT IN(${tablesToExclude})`;


### PR DESCRIPTION
Fixes the issue when WHERE IN statement wrapped table names in double quotes results in the error "Unknown column"

```
SHOW FULL TABLES IN `dbname` WHERE 1 = 1 AND Tables_in_dbname NOT IN("users");
ERROR 1054 (42S22): Unknown column 'users' in 'where clause'
```