### PR TITLE
[FEATURE] Specify Column Order of Data for Copy Command

### DIFF
--- a/src/DataReader.ts
+++ b/src/DataReader.ts
@@ -41,6 +41,7 @@ import {
     MessageToDataReader,
     MessageToDataWriter,
     CopyStreamSerializableParams,
+    Table,
 } from './Types';
 
 /**
@@ -79,7 +80,12 @@ const populateTable = async (conv: Conversion, chunk: any): Promise<void> => {
     const originalTableName: string = extraConfigProcessor.getTableName(conv, tableName, true);
     const sql = `SELECT ${strSelectFieldList} FROM \`${originalTableName}\`;`;
     const mysqlClient: PoolConnection = await DBAccess.getMysqlClient(conv);
-    const sqlCopy = `COPY "${conv._schema}"."${tableName}" FROM STDIN 
+    // use dicTables to specify column order of data coming in
+    const tableMap = new Map<string, Table>(conv._config._dicTables);
+    let columnNames = '';
+    const table = tableMap.get(tableName);
+    if (table) columnNames = `(${table.arrTableColumns.map(c => `"${c.Field.toLowerCase()}"`).join()})`;
+    const sqlCopy = `COPY "${conv._schema}"."${tableName}" ${columnNames} FROM STDIN 
                              WITH(FORMAT csv, DELIMITER '${conv._delimiter}',
                              ENCODING '${conv._targetConString.charset}');`;
 

--- a/src/StructureLoader.ts
+++ b/src/StructureLoader.ts
@@ -135,5 +135,7 @@ export default async (conversion: Conversion): Promise<Conversion> => {
     await log(conversion, message);
     await Promise.all(processTablePromises);
     await migrationStateManager.set(conversion, 'tables_loaded');
+    // make the table dictionary serializable for the DefaultReader
+    conversion._config._dicTables = [...conversion._dicTables];
     return conversion;
 };


### PR DESCRIPTION
There are issues if the column order of the mysql table does not exactly match the order for the postgresql table.

This updates the `StructureLoader` to include a serializable version of the `_dictTables`, so that after deserialized the `DataReader.populateTable` can specify the column order for the data coming in. 