### PR TITLE
[FIX] Rename filenames used during runtime to kebab case

### DIFF
--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -306,8 +306,8 @@ export default class Conversion {
    */
   private _setLogger = (): ChildProcess => {
     // A path to the FsOps.js file.
-    // Note, in runtime it points to ../dist/src/LogsProcessor.js and not LogsProcessor.ts
-    const loggerPath: string = path.join(__dirname, 'LogsProcessor.js');
+    // Note, in runtime it points to ../dist/src/logs-processor.js and not logs-processor.ts
+    const loggerPath: string = path.join(__dirname, 'logs-processor.js');
 
     const logger: ChildProcess = fork(loggerPath)
       .on('error', (err: Error) => console.log(`\t--[_setLogger] Error: ${JSON.stringify(err)}`))

--- a/src/data-pipe-manager.ts
+++ b/src/data-pipe-manager.ts
@@ -52,9 +52,9 @@ export default class DataPipeManager {
 
   /**
    * A path to the DataReader.js file.
-   * Note, in runtime it points to ../dist/src/DataReader.js and not DataReader.ts
+   * Note, in runtime it points to ../dist/src/data-reader.js and not data-reader.ts
    */
-  private static readonly dataReaderPath = path.join(__dirname, 'DataReader.js');
+  private static readonly dataReaderPath = path.join(__dirname, 'data-reader.js');
 
   /**
    * Returns the options object, which intended to be used upon creation of the data reader process.

--- a/src/data-reader.ts
+++ b/src/data-reader.ts
@@ -81,7 +81,7 @@ const populateTable = async (conv: Conversion, chunk: any): Promise<void> => {
   const originalTableName: string = extraConfigProcessor.getTableName(conv, tableName, true);
   const sql = `SELECT ${strSelectFieldList} FROM \`${originalTableName}\`;`;
   const mysqlClient: PoolConnection = await DbAccess.getMysqlClient(conv);
-  const sqlCopy = `COPY "${conv._schema}"."${tableName}" (${copyColumnNamesList}) FROM STDIN 
+  const sqlCopy = `COPY "${conv._schema}"."${tableName}" (${copyColumnNamesList}) FROM STDIN
         WITH (FORMAT csv, DELIMITER '${conv._delimiter}', ENCODING '${conv._targetConString.charset}');`;
 
   const client: PoolClient = await DbAccess.getPgClient(conv);
@@ -135,8 +135,8 @@ const populateTable = async (conv: Conversion, chunk: any): Promise<void> => {
  * Spawns the data-writer child-process and returns its instance.
  */
 const getDataWriter = (conv: Conversion): ChildProcess => {
-  // Note, in runtime it points to ../dist/src/DataWriter.js and not DataWriter.ts
-  const cliArgs: string[] = [path.join(__dirname, 'DataWriter.js')];
+  // Note, in runtime it points to ../dist/src/data-writer.js and not data-writer.ts
+  const cliArgs: string[] = [path.join(__dirname, 'data-writer.js')];
 
   if (conv._readerMaxOldSpaceSize !== 'DEFAULT') {
     // Note, all the child-process params are equally applicable to both "DataReader" and "DataWriter" processes.


### PR DESCRIPTION
This pull request fixes missing kebab case updates for certain runtime-only file paths. While imports were updated to kebab case in a previous commit, some dynamically-referenced files still used camel case.

Changes include:
- Updating `DataWriter.js` to `data-writer.js`
- Updating `DataReader.js` to `data-reader.js`
- Updating `LogsProcessor.js` to `logs-processor.js`

Thank you for this project, I just discovered it today and it has been extremely helpful