### PR TITLE
#144 Handle lower case relation name

### DIFF
--- a/src/structure-loader.ts
+++ b/src/structure-loader.ts
@@ -105,6 +105,9 @@ export default async (conversion: Conversion): Promise<Conversion> => {
 
   result.data.forEach((row: any) => {
     let relationName: string = row[`Tables_in_${conversion._mySqlDbName}`];
+    if(!relationName) {
+      relationName = row[`Tables_in_${conversion._mySqlDbName.toLowerCase()}`];
+    }
 
     if (row.Table_type === 'BASE TABLE' && conversion._excludeTables.indexOf(relationName) === -1) {
       relationName = extraConfigProcessor.getTableName(conversion, relationName, false);


### PR DESCRIPTION
This fixes the problem of the relation name being lowercase (I'm guessing this is different in newer versions of MySQL?).